### PR TITLE
Add support for yt shorts

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ const greekQuestionMark = (from, message, channel, c) => {
 
 const getYoutubeId = (message) => {
   const regexp =
-    /((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed\/|v\/)?)(?<id>([\w\-]+)(\S+)?)/g;
+    /((?:https?:)?\/\/)?((?:www|m)\.)?((?:youtube\.com|youtu.be))(\/(?:[\w\-]+\?v=|embed|shorts\/|v\/)?)(?<id>([\w\-]+)(\S+)?)/g;
   const exec = regexp.exec(message);
   return exec && exec.groups && exec.groups.id;
 };


### PR DESCRIPTION
Adds support for videos like: https://www.youtube.com/shorts/jq_jEDsp7Ww

I only tested `getYoutubeId()` itself to make sure an id was returned.